### PR TITLE
Watch insets on android.id.content instead of the decorView

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".examples.FullScreenActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/de/halfbit/edgetoedge/sample/MainAdapter.kt
+++ b/app/src/main/java/de/halfbit/edgetoedge/sample/MainAdapter.kt
@@ -14,34 +14,13 @@ class MainAdapter(
 ) : RecyclerView.Adapter<ItemViewHolder>() {
 
     private var items = listOf(
-        Item(
-            nameId = R.string.splash,
-            onClick = OnClick.CreateFragment { SplashScreenFragment() }
-        ),
-        Item(
-            nameId = R.string.toolbar,
-            onClick = OnClick.CreateFragment { ToolbarWithScrollableContentFragment() }
-        ),
-        Item(
-            nameId = R.string.toolbar_fab,
-            onClick = OnClick.CreateFragment { ToolbarWithScrollableContentAndFabFragment() }
-        ),
-        Item(
-            nameId = R.string.toolbar_viewpager,
-            onClick = OnClick.CreateFragment { ToolbarWithViewpagerFragment() }
-        ),
-        Item(
-            nameId = R.string.bottom_sheet_dialog,
-            onClick = OnClick.CreateFragment { BottomSheetDialogFragment() }
-        ),
-        Item(
-            nameId = R.string.constraint_layout_transitions,
-            onClick = OnClick.CreateFragment { ConstraintLayoutTransitionsFragment() }
-        ),
-        Item(
-            nameId = R.string.full_screen_activity,
-            onClick = OnClick.CreateActivity(FullScreenActivity::class.java)
-        )
+        Item(R.string.splash, OnClick.CreateFragment { SplashScreenFragment() }),
+        Item(R.string.toolbar,OnClick.CreateFragment { ToolbarWithScrollableContentFragment() }),
+        Item(R.string.toolbar_fab, OnClick.CreateFragment { ToolbarWithScrollableContentAndFabFragment() }),
+        Item(R.string.toolbar_viewpager, OnClick.CreateFragment { ToolbarWithViewpagerFragment() }),
+        Item(R.string.bottom_sheet_dialog, OnClick.CreateFragment { BottomSheetDialogFragment() }),
+        Item(R.string.constraint_layout_transitions, OnClick.CreateFragment { ConstraintLayoutTransitionsFragment() }),
+        Item(R.string.full_screen_activity, OnClick.CreateActivity(FullScreenActivity::class.java))
     )
 
     override fun getItemCount(): Int = items.size

--- a/app/src/main/java/de/halfbit/edgetoedge/sample/MainAdapter.kt
+++ b/app/src/main/java/de/halfbit/edgetoedge/sample/MainAdapter.kt
@@ -1,24 +1,47 @@
 package de.halfbit.edgetoedge.sample
 
+import android.app.Activity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
-import androidx.annotation.StringRes
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.RecyclerView
 import de.halfbit.edgetoedge.sample.examples.*
 
-class MainAdapter(private val onItemClicked: OnItemClicked) :
-    RecyclerView.Adapter<ItemViewHolder>() {
+class MainAdapter(
+    private val onClick: (OnClick) -> Unit
+) : RecyclerView.Adapter<ItemViewHolder>() {
 
     private var items = listOf(
-        Item(R.string.splash) { SplashScreenFragment() },
-        Item(R.string.toolbar) { ToolbarWithScrollableContentFragment() },
-        Item(R.string.toolbar_fab) { ToolbarWithScrollableContentAndFabFragment() },
-        Item(R.string.toolbar_viewpager) { ToolbarWithViewpagerFragment() },
-        Item(R.string.bottom_sheet_dialog) { BottomSheetDialogFragment() },
-        Item(R.string.constraint_layout_transitions) { ConstraintLayoutTransitionsFragment() }
+        Item(
+            nameId = R.string.splash,
+            onClick = OnClick.CreateFragment { SplashScreenFragment() }
+        ),
+        Item(
+            nameId = R.string.toolbar,
+            onClick = OnClick.CreateFragment { ToolbarWithScrollableContentFragment() }
+        ),
+        Item(
+            nameId = R.string.toolbar_fab,
+            onClick = OnClick.CreateFragment { ToolbarWithScrollableContentAndFabFragment() }
+        ),
+        Item(
+            nameId = R.string.toolbar_viewpager,
+            onClick = OnClick.CreateFragment { ToolbarWithViewpagerFragment() }
+        ),
+        Item(
+            nameId = R.string.bottom_sheet_dialog,
+            onClick = OnClick.CreateFragment { BottomSheetDialogFragment() }
+        ),
+        Item(
+            nameId = R.string.constraint_layout_transitions,
+            onClick = OnClick.CreateFragment { ConstraintLayoutTransitionsFragment() }
+        ),
+        Item(
+            nameId = R.string.full_screen_activity,
+            onClick = OnClick.CreateActivity(FullScreenActivity::class.java)
+        )
     )
 
     override fun getItemCount(): Int = items.size
@@ -27,7 +50,7 @@ class MainAdapter(private val onItemClicked: OnItemClicked) :
             itemView = LayoutInflater.from(parent.context).inflate(
                 R.layout.fragment_main_item, parent, false
             ),
-            onItemClicked = onItemClicked
+            onClick = onClick
         )
 
     override fun onBindViewHolder(holder: ItemViewHolder, position: Int) {
@@ -36,19 +59,22 @@ class MainAdapter(private val onItemClicked: OnItemClicked) :
 }
 
 class Item(
-    @StringRes val nameId: Int,
-    val factory: FragmentFactory
+    val nameId: Int,
+    val onClick: OnClick
 )
 
+sealed class OnClick {
+    class CreateFragment(val createFragment: () -> Fragment) : OnClick()
+    class CreateActivity(val activity: Class<out Activity>) : OnClick()
+}
+
 class ItemViewHolder(
-    itemView: View, val onItemClicked: OnItemClicked
+    itemView: View,
+    val onClick: (OnClick) -> Unit
 ) : RecyclerView.ViewHolder(itemView) {
     fun bind(item: Item) {
         val textView = itemView as TextView
         textView.setText(item.nameId)
-        textView.setOnClickListener { onItemClicked(item.factory) }
+        textView.setOnClickListener { onClick(item.onClick) }
     }
 }
-
-typealias FragmentFactory = () -> Fragment
-typealias OnItemClicked = (FragmentFactory) -> Unit

--- a/app/src/main/java/de/halfbit/edgetoedge/sample/MainFragment.kt
+++ b/app/src/main/java/de/halfbit/edgetoedge/sample/MainFragment.kt
@@ -1,5 +1,6 @@
 package de.halfbit.edgetoedge.sample
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -22,13 +23,20 @@ class MainFragment : BaseFragment() {
         }
 
         recycler.addItemDecoration(DividerItemDecoration(context, DividerItemDecoration.VERTICAL))
-        recycler.adapter = MainAdapter { createFragment ->
-            requireActivity()
-                .supportFragmentManager
-                .beginTransaction()
-                .replace(R.id.container, createFragment())
-                .addToBackStack(null)
-                .commit()
+        recycler.adapter = MainAdapter { onClick ->
+            when (onClick) {
+                is OnClick.CreateFragment -> {
+                    requireActivity()
+                        .supportFragmentManager
+                        .beginTransaction()
+                        .replace(R.id.container, onClick.createFragment())
+                        .addToBackStack(null)
+                        .commit()
+                }
+                is OnClick.CreateActivity -> {
+                    startActivity(Intent(context, onClick.activity))
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/de/halfbit/edgetoedge/sample/examples/FullScreenActivity.kt
+++ b/app/src/main/java/de/halfbit/edgetoedge/sample/examples/FullScreenActivity.kt
@@ -1,0 +1,18 @@
+package de.halfbit.edgetoedge.sample.examples
+
+import android.os.Bundle
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import de.halfbit.edgetoedge.Edge
+import de.halfbit.edgetoedge.edgeToEdge
+import de.halfbit.edgetoedge.sample.R
+
+class FullScreenActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_full_screen)
+        edgeToEdge {
+            findViewById<View>(R.id.message).fit { Edge.BottomArc }
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_full_screen.xml
+++ b/app/src/main/res/layout/activity_full_screen.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/holo_blue_dark"
+    android:paddingStart="24dp"
+    android:paddingEnd="24dp"
+    android:paddingBottom="8dp"
+    tools:context="de.halfbit.edgetoedge.sample.MainActivity">
+
+    <TextView
+        android:id="@+id/message"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|center_horizontal"
+        android:text="@string/full_screen_message"
+        android:textAlignment="center"
+        android:textColor="@android:color/white"
+        android:textSize="16sp" />
+
+</FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,8 @@
     <string name="option2">Option 2</string>
     <string name="option3">Option 3</string>
     <string name="constraint_layout_transitions">ConstraintLayout + Transitions</string>
+    <string name="full_screen_activity">Full screen activity</string>
+    <string name="full_screen_message">It is a full screen activity. This long message should not be covered by any of system bars.</string>
     <string name="tap_to_expand">Tap to expand</string>
     <string name="polar_light">An aurora (plural: auroras or aurorae),[a] sometimes referred to as polar lights, northern lights (aurora borealis), or southern lights (aurora australis), is a natural light display in the Earth\'s sky, predominantly seen in the high-latitude regions (around the Arctic and Antarctic).</string>
 </resources>

--- a/buildSrc/src/main/kotlin/Pom.kt
+++ b/buildSrc/src/main/kotlin/Pom.kt
@@ -6,7 +6,7 @@ object Pom {
 
     const val group = "de.halfbit"
     const val artifactId = "edge-to-edge"
-    const val version = "0.10"
+    const val version = "1.0-rc1"
 
     object License {
         const val name = "The Apache License, Version 2.0"

--- a/buildSrc/src/main/kotlin/Version.kt
+++ b/buildSrc/src/main/kotlin/Version.kt
@@ -1,6 +1,6 @@
 object Version {
     const val kotlin = "1.3.72"
-    const val agp = "3.5.3"
+    const val agp = "4.0.0"
     const val dokka = "0.10.0"
     const val jvmTarget = "1.8"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Dec 24 12:45:58 CET 2019
+#Mon Jun 15 19:40:24 CEST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/library/src/main/java/de/halfbit/edgetoedge/EdgeToEdgeExtensions.kt
+++ b/library/src/main/java/de/halfbit/edgetoedge/EdgeToEdgeExtensions.kt
@@ -2,17 +2,18 @@ package de.halfbit.edgetoedge
 
 import android.app.Activity
 import android.app.Dialog
+import android.view.View
 import android.view.Window
 import androidx.fragment.app.Fragment
 
 /**
  * Declares a set of view fitting rules and requests [android.view.WindowInsets] to be
  * applied to the view hierarchy. The library will fit the views according to their
- * fitting rules each time [WindowInsets] are applied. The set is usually declared in
+ * fitting rules each time [android.view.WindowInsets] are applied. The set is usually declared in
  * the `Fragment.onViewCreated()` callback, but it can be re-declared at any time later,
- * for instance after applying a [ConstraintSet]. Each declaration adds new or overwrites
- * already existing view fitting rules. For removing a fitting rule [EdgeToEdgeBuilder.unfit]
- * method can be used.
+ * for instance after applying a [androidx.constraintlayout.widget.ConstraintSet].
+ * Each declaration adds new or overwrites already existing view fitting rules. For removing
+ * a fitting rule [EdgeToEdgeBuilder.unfit] method can be used.
  *
  * ```
  * override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -40,18 +41,20 @@ fun Fragment.fitEdgeToEdge() {
 
 inline fun Dialog.edgeToEdge(block: EdgeToEdgeBuilder.() -> Unit) {
     val window = requireNotNull(window) { "Dialog's window must be not null" }
-    EdgeToEdgeBuilder(window.decorView, window).also(block).build()
+    val contentView = findViewById<View>(android.R.id.content)
+    EdgeToEdgeBuilder(contentView, window).also(block).build()
 }
 
 inline fun Activity.edgeToEdge(block: EdgeToEdgeBuilder.() -> Unit) {
-    val window = requireNotNull(window) { "Dialog's window must be not null" }
-    EdgeToEdgeBuilder(window.decorView, window).also(block).build()
+    val window = requireNotNull(window) { "Activity's window must be not null" }
+    val contentView = findViewById<View>(android.R.id.content)
+    EdgeToEdgeBuilder(contentView, window).also(block).build()
 }
 
 fun Window.setEdgeToEdgeFlags() {
     with(decorView) {
         systemUiVisibility = systemUiVisibility or
-                android.view.View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
-                android.view.View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
+                View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
     }
 }


### PR DESCRIPTION
Fixes #2 

- Content view (with id `android.id.content`) is used in Activity and Dialog instead of the decorView.

Thanks a lot @thierryd for reporting and finding the solution!